### PR TITLE
refactor: remove reflect from mergeMaps and reduce replace() calls

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -117,12 +117,14 @@ func (m *Config) Run(migration io.Reader) error {
 		return errors.Wrapf(err, "failed to parse %s", m.path)
 	}
 
+	// Remove migration-specific metadata
+	delete(migrMap, "force")
+	delete(fileMap, "force")
+	delete(migrMap, "version")
+	delete(fileMap, "version")
+
 	// Merge current config and migration changes
 	base := merger.Merge(migrMap, fileMap)
-
-	// Remove migration-specific metadata
-	delete(base, "version")
-	delete(base, "force")
 
 	// Marshal merged data to bytes
 	data, err := m.driver.Marshal(base, false)

--- a/replacer/replacer.go
+++ b/replacer/replacer.go
@@ -33,3 +33,7 @@ func Replace(value string) string {
 
 	return value
 }
+
+func HasReplacers() bool {
+	return len(replacers) > 0
+}


### PR DESCRIPTION
- Removed use of reflect.TypeOf to improve performance
- Reduced unnecessary calls to replace(), now only used when value is written to output
- Updated logic to use type assertions and switch statements instead of reflection